### PR TITLE
Updated durations request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.1
+
+Oct 12, 2023
+- Removes the default seed of synthesize (previously 0). When seed is unspecified, synthesize will now use a random seed.
+- The durations dictionary has been updated. Now includes each word itself and changes durations from # of samples to seconds.
+
 # 0.2.0
 
 Sep 7, 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 Oct 12, 2023
 - Removes the default seed of synthesize (previously 0). When seed is unspecified, synthesize will now use a random seed.
-- The durations dictionary has been updated. Now includes each word itself and changes durations from # of samples to seconds.
+- The durations dictionary has been updated. Now includes each word itself and changes the units of duration from the number of samples to seconds.
 
 # 0.2.0
 

--- a/src/lmnt/api.py
+++ b/src/lmnt/api.py
@@ -133,7 +133,7 @@ class Speech:
 
     has_durations = kwargs.get('durations', False)
     if has_durations:
-      extras = 'alignment'
+      extras = 'durations'
       is_multipart_response = True
 
     if extras:
@@ -142,65 +142,14 @@ class Speech:
     async with self._session.post(url, data=form_data, headers=self._build_headers()) as resp:
       if is_multipart_response:
         response = await self._parse_multipart_alignment_response(resp)
-        word_durations = self._transform_to_word_durations(response['duration'], response['phonemes'])
         return {
-            'durations': word_durations,
+            'durations': response['durations'],
             'audio': response['audio']
         }
 
       else:
         await self._handle_response_errors(resp)
         return await resp.read()
-
-  def _transform_to_word_durations(self, durations, phonemes):
-    if not durations or not phonemes or len(durations) != len(phonemes):
-      raise ValueError("Invalid word durations input data.")
-
-    result = []
-    acc_phonemes, acc_durations = [], []
-    total_duration, start = 0, 0
-
-    for dur, phon in zip(durations, phonemes):
-      if phon == " ":
-        # Emit current accumulation if we have some.
-        if len(acc_phonemes) > 0:
-          result.append(self._create_duration_entry(
-              acc_phonemes, acc_durations, start, total_duration))
-
-        # Reset accumulation.
-        start += total_duration
-        acc_phonemes.clear()
-        acc_durations.clear()
-
-        # Emit the whitespace itself.
-        duration_samples = dur * _SAMPLES_PER_FRAME
-        total_duration = duration_samples
-        result.append(self._create_duration_entry(
-            [" "], [duration_samples], start, total_duration))
-        start += total_duration
-        total_duration = 0
-
-      else:
-        # Accumulate the phoneme.
-        acc_phonemes.append(phon)
-        duration_samples = dur * _SAMPLES_PER_FRAME
-        acc_durations.append(duration_samples)
-        total_duration += duration_samples
-
-    # Emit any remaining accumulation.
-    if len(acc_phonemes) > 0:
-      result.append(self._create_duration_entry(
-          acc_phonemes, acc_durations, start, total_duration))
-
-    return result
-
-  def _create_duration_entry(self, phonemes, durations, start, total_duration):
-    return {
-        'phonemes': phonemes.copy(),
-        'phoneme_durations': durations.copy(),
-        'start': start,
-        'duration': total_duration
-    }
 
   async def _get_next_content(self, reader):
     response = await reader.next()
@@ -211,12 +160,10 @@ class Speech:
   async def _parse_multipart_alignment_response(self, response):
     reader = aiohttp.MultipartReader.from_response(response)
     # Requesting alignment information returns a three-part multipart response:
-    # 1. JSON of `duration` in frames.
-    # 2. JSON of `phonemes`.
+    # 1. JSON of `durations` in seconds.
     # 3. Binary audio data.
     return {
-        'duration': await self._get_next_content(reader),
-        'phonemes': await self._get_next_content(reader),
+        'durations': await self._get_next_content(reader),
         'audio': await self._get_next_content(reader)}
 
   async def synthesize_streaming(self, voice):

--- a/src/lmnt/api.py
+++ b/src/lmnt/api.py
@@ -159,9 +159,9 @@ class Speech:
 
   async def _parse_multipart_alignment_response(self, response):
     reader = aiohttp.MultipartReader.from_response(response)
-    # Requesting alignment information returns a three-part multipart response:
+    # Requesting alignment information returns a two-part multipart response:
     # 1. JSON of `durations` in seconds.
-    # 3. Binary audio data.
+    # 2. Binary audio data.
     return {
         'durations': await self._get_next_content(reader),
         'audio': await self._get_next_content(reader)}

--- a/src/lmnt/test_api.py
+++ b/src/lmnt/test_api.py
@@ -1,0 +1,38 @@
+import pytest
+from api import Speech
+
+X_API_KEY = ""
+STAGING_URL = 'https://api.staging.lmnt.com'
+PROD_URL = 'https://api.lmnt.com'
+
+@pytest.fixture
+async def api():
+    async with Speech(X_API_KEY, _BASE_URL=STAGING_URL) as speech:
+        yield speech
+
+@pytest.mark.asyncio
+async def test_init(api):
+    assert api is not None
+
+@pytest.mark.asyncio
+async def test_list_voices(api):
+    voices = await api.list_voices()
+    assert isinstance(voices, dict)
+    assert len(voices) > 0
+
+@pytest.mark.asyncio
+async def test_synthesize_streaming(api):
+    voice = 'shanti'
+    result = await api.synthesize_streaming(voice)
+    assert result is not None
+
+@pytest.mark.asyncio
+async def test_durations(api):
+    voice = 'shanti'
+    text = 'Example Text'
+    result = await api.synthesize(text=text, voice=voice, durations=True)
+    assert result is not None
+    assert 'durations' in result
+    assert 'audio' in result
+    assert len(result['durations']) > 0
+    assert len(result['audio']) > 0

--- a/src/lmnt/test_api.py
+++ b/src/lmnt/test_api.py
@@ -33,6 +33,21 @@ async def test_durations(api):
     result = await api.synthesize(text=text, voice=voice, durations=True)
     assert result is not None
     assert 'durations' in result
+    assert 'phonemes' not in result
     assert 'audio' in result
     assert len(result['durations']) > 0
     assert len(result['audio']) > 0
+
+@pytest.mark.asyncio
+async def test_synthesize_with_invalid_voice(api):
+    voice = 'invalid_voice'
+    text = 'Example Text'
+    with pytest.raises(Exception):
+        await api.synthesize(text=text, voice=voice)
+
+@pytest.mark.asyncio
+async def test_synthesize_with_empty_text(api):
+    voice = 'shanti'
+    text = ''
+    with pytest.raises(Exception):
+        await api.synthesize(text=text, voice=voice)

--- a/test/smoke_test.py
+++ b/test/smoke_test.py
@@ -1,7 +1,12 @@
 import pytest
-from api import Speech
+import os
+import sys
 
-X_API_KEY = ""
+sys.path.append(os.path.expandvars('$LMNT_ROOT/sdk/lmnt-python/src'))
+from lmnt.api import Speech # noqa
+
+# Set an API key in your environment to run these tests
+X_API_KEY = os.environ['X_API_KEY']
 STAGING_URL = 'https://api.staging.lmnt.com'
 PROD_URL = 'https://api.lmnt.com'
 


### PR DESCRIPTION
Updates the python SDK to grab the new durations object.
- Added some simple tests with test_api.py, although unsure how to navigate needing the API key. Don't want to check in a useable key. Is there a better way to do this? 