### PR TITLE
Add github action to build and publish to pypi

### DIFF
--- a/.github/publish.yml
+++ b/.github/publish.yml
@@ -1,0 +1,17 @@
+name: Publish to PyPI.org
+on:
+  release:
+    types: [published]
+jobs:
+  pypi:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: python3 -m pip install --upgrade build && python3 -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1a
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,12 @@
+[project]
+dynamic = ["version"]
+
+[build-system]
+requires = ["setuptools>=45", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+
 [tool.ruff]
 cache-dir = "~/.cache/ruff"
 line-length = 160

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from setuptools import find_namespace_packages, setup
 
 
-VERSION = '1.1.0'
 DESCRIPTION = 'Python client library for the LMNT API'
 AUTHOR = 'LMNT, Inc.'
 AUTHOR_EMAIL = 'feedback@lmnt.com'
@@ -15,7 +14,6 @@ CLASSIFIERS = [
 ]
 
 setup(name='lmnt',
-      version=VERSION,
       description=DESCRIPTION,
       long_description=open('README.md', 'r').read(),
       long_description_content_type='text/markdown',


### PR DESCRIPTION
Currently a one-step manual process to publish a release.

We switch over to setuptools_scm so the version number comes from the github tags, and remove the explicitly configured version number.