### PR TITLE
ci: matrix tests across supported Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,13 @@ jobs:
 
   test:
     timeout-minutes: 10
-    name: test
+    name: test (py${{ matrix.python-version }})
     runs-on: ${{ github.repository == 'stainless-sdks/lmnt-com-python' && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
     if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
     steps:
       - uses: actions/checkout@v4
 
@@ -66,6 +70,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
+          python-version: ${{ matrix.python-version }}
 
       - name: Bootstrap
         run: ./scripts/bootstrap


### PR DESCRIPTION
Run scripts/test on every Python version listed in pyproject.toml classifiers (3.10–3.14). fail-fast: false so a flake on one version doesn't mask others. lint and build stay single-version since their output doesn't vary across minors.