### PR TITLE
Fix import ordering in generated types

### DIFF
--- a/_carbonsteel.json
+++ b/_carbonsteel.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-26T01:00:12Z",
+  "generated_at": "2026-04-26T04:27:44Z",
   "spec_sha": "b8435ec93cccd280:510635fad1875bc4",
   "files": [
     "api.md",

--- a/src/lmnt/types/__init__.py
+++ b/src/lmnt/types/__init__.py
@@ -14,8 +14,8 @@ from .speech_convert_params import SpeechConvertParams as SpeechConvertParams
 from .voice_delete_response import VoiceDeleteResponse as VoiceDeleteResponse
 from .voice_update_response import VoiceUpdateResponse as VoiceUpdateResponse
 from .speech_generate_params import SpeechGenerateParams as SpeechGenerateParams
-from .speech_stream_eof_command import SpeechStreamEofCommand as SpeechStreamEofCommand
 from .account_retrieve_response import AccountRetrieveResponse as AccountRetrieveResponse
+from .speech_stream_eof_command import SpeechStreamEofCommand as SpeechStreamEofCommand
 from .speech_stream_init_message import SpeechStreamInitMessage as SpeechStreamInitMessage
 from .speech_stream_text_message import SpeechStreamTextMessage as SpeechStreamTextMessage
 from .speech_stream_flush_command import SpeechStreamFlushCommand as SpeechStreamFlushCommand

--- a/src/lmnt/types/speech_stream_extras.py
+++ b/src/lmnt/types/speech_stream_extras.py
@@ -3,8 +3,8 @@
 from typing import List, Optional
 from typing_extensions import Literal
 
-from .duration import Duration
 from .._models import BaseModel
+from .duration import Duration
 
 __all__ = ["SpeechStreamExtras"]
 

--- a/src/lmnt/types/speech_stream_init_message.py
+++ b/src/lmnt/types/speech_stream_init_message.py
@@ -4,6 +4,7 @@ from typing import Optional
 from typing_extensions import Literal
 
 from pydantic import Field
+
 from .._models import BaseModel
 
 __all__ = ["SpeechStreamInitMessage"]


### PR DESCRIPTION
Follow-up to #71. Adjusts import ordering and grouping in three generated `types/` files so they pass `ruff check`.