### PR TITLE
docs: link LMNT API reference in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/lmnt.svg?label=pypi%20(stable))](https://pypi.org/project/lmnt/)
 
-The LMNT Python SDK provides convenient access to the LMNT API from Python applications.
+The LMNT Python SDK provides convenient access to the [LMNT API](https://docs.lmnt.com/api/) from Python applications.
 
 ## Documentation
 


### PR DESCRIPTION
Link "LMNT API" in the README intro to https://docs.lmnt.com/api/.