### PR TITLE
docs: refresh speech session descriptions

### DIFF
--- a/_carbonsteel.json
+++ b/_carbonsteel.json
@@ -1,7 +1,7 @@
 {
   "version": "1.1",
-  "generated_at": "2026-05-09T12:18:20Z",
-  "spec_sha": "4c822a78c44f68ac:53f7f73325c83be4",
+  "generated_at": "2026-05-09T14:25:01Z",
+  "spec_sha": "4c822a78c44f68ac:cc7f4554e955f4fe",
   "files": [
     "api.md",
     "src/lmnt/__init__.py",

--- a/src/lmnt/resources/sessions.py
+++ b/src/lmnt/resources/sessions.py
@@ -134,17 +134,17 @@ class SpeechSession:
       await self.websocket.send(json.dumps(init_msg))
 
   async def send_text(self, text: str) -> None:
-    """The text you send can be split at any point."""
+    """Send text to the server to append into the text stream."""
     await self._send_message({"type": "text", "text": text})
 
   async def send_flush(self) -> int:
-    """Each `flush` carries a client-chosen `nonce`. The server replies with a `flush_complete` carrying the matching nonce once it has finished streaming the flushed audio."""
+    """Force the server to generate speech for all buffered text in the stream."""
     self.nonce += 1
     await self._send_message({"type": "flush", "nonce": self.nonce})
     return self.nonce
 
   async def send_reset(self) -> int:
-    """Each `reset` carries a client-chosen `nonce`. The server replies with a `reset_complete` carrying the matching nonce once the buffer has been cleared."""
+    """Drop the server's buffered text without generating speech for it."""
     self.nonce += 1
     await self._send_message({"type": "reset", "nonce": self.nonce})
     return self.nonce

--- a/src/lmnt/types/speech_session_error.py
+++ b/src/lmnt/types/speech_session_error.py
@@ -12,7 +12,10 @@ class SpeechSessionError(BaseModel):
   error: ErrorBody
 
   request_id: str  # pyright: ignore[reportIncompatibleVariableOverride, reportGeneralTypeIssues]
-  """Per-session request ID for log correlation."""
+  """Per-session request ID.
+
+    If you're reporting an issue, include this if possible to make debugging easier.
+    """
 
   type: Literal["error"] = "error"
   """Discriminator identifying this message type."""

--- a/src/lmnt/types/speech_session_ready.py
+++ b/src/lmnt/types/speech_session_ready.py
@@ -9,9 +9,9 @@ __all__ = ["SpeechSessionReady"]
 
 class SpeechSessionReady(BaseModel):
   request_id: str  # pyright: ignore[reportIncompatibleVariableOverride, reportGeneralTypeIssues]
-  """
-    Per-session request ID — same value as the `request-id` HTTP header on the WS
-    upgrade response. Use it to correlate session activity with server-side logs.
+  """Per-session request ID.
+
+    If you're reporting an issue, include this if possible to make debugging easier.
     """
 
   type: Literal["ready"] = "ready"


### PR DESCRIPTION
## Summary
Refresh the docstrings on the `SpeechSession` send methods and on the `SpeechSessionReady` / `SpeechSessionError` message types so they read more clearly and consistently. No method signatures or types changed.

## Changed surface
- speech-sessions: docstrings on `SpeechSession.send_text`, `send_flush`, and `send_reset`
- speech-sessions: docstrings on the `request_id` field of `SpeechSessionReady` and `SpeechSessionError`